### PR TITLE
Fix step labeling in pipeline prep jobs

### DIFF
--- a/.github/workflows/pipeline-prep.yml
+++ b/.github/workflows/pipeline-prep.yml
@@ -399,8 +399,24 @@ jobs:
           : >"$STATUS"; : >"$LOG"; : >"$ERR"; : >"$SUM"
 
           ts(){ TZ="America/New_York" date +"%Y-%m-%d %I:%M:%S %p %Z"; }
-          run_step(){ echo "▶️ START: $1 ($(ts))" >>"$LOG"; shift; "$@" >>"$LOG" 2>step.err; rc=$?; if [ $rc -eq 0 ]; then echo "✅ $1 succeeded [$(ts)]" >>"$STATUS"; else echo "❌ $1 failed [$(ts)]" >>"$STATUS"; { echo "❌ $1 ERROR [$(ts)]:";
-            cat step.err; echo; echo '---'; echo; } >>"$ERR"; fi; rm -f step.err; echo "⏹️ END: $1 ($(ts))" >>"$LOG"; echo >>"$LOG"; }
+          run_step(){
+            local step="$1"
+            shift
+            echo "▶️ START: ${step} ($(ts))" >>"$LOG"
+            "$@" >>"$LOG" 2>step.err
+            rc=$?
+            if [ $rc -eq 0 ]; then
+              echo "✅ ${step} succeeded [$(ts)]" >>"$STATUS"
+            else
+              echo "❌ ${step} failed [$(ts)]" >>"$STATUS"
+              { echo "❌ ${step} ERROR [$(ts)]:"
+                cat step.err
+                echo; echo '---'; echo; } >>"$ERR"
+            fi
+            rm -f step.err
+            echo "⏹️ END: ${step} ($(ts))" >>"$LOG"
+            echo >>"$LOG"
+          }
 
           run_step apply_weather_adjustment.py       python scripts/apply_weather_adjustment.py
           run_step apply_park_adjustment.py          python scripts/apply_park_adjustment.py
@@ -574,7 +590,24 @@ jobs:
           : >"$STATUS"; : >"$LOG"; : >"$ERR"; : >"$SUM"
 
           ts(){ TZ="America/New_York" date +"%Y-%m-%d %I:%M:%S %p %Z"; }
-          run_step(){ echo "▶️ START: $1 ($(ts))" >>"$LOG"; shift; "$@" >>"$LOG" 2>step.err; rc=$?; if [ $rc -eq 0 ]; then echo "✅ $1 succeeded [$(ts)]" >>"$STATUS"; else echo "❌ $1 failed [$(ts)]" >>"$STATUS"; { echo "❌ $1 ERROR [$(ts)]:"; cat step.err; echo; echo '---'; echo; } >>"$ERR"; fi; rm -f step.err; echo "⏹️ END: $1 ($(ts))" >>"$LOG"; echo >>"$LOG"; }
+          run_step(){
+            local step="$1"
+            shift
+            echo "▶️ START: ${step} ($(ts))" >>"$LOG"
+            "$@" >>"$LOG" 2>step.err
+            rc=$?
+            if [ $rc -eq 0 ]; then
+              echo "✅ ${step} succeeded [$(ts)]" >>"$STATUS"
+            else
+              echo "❌ ${step} failed [$(ts)]" >>"$STATUS"
+              { echo "❌ ${step} ERROR [$(ts)]:"
+                cat step.err
+                echo; echo '---'; echo; } >>"$ERR"
+            fi
+            rm -f step.err
+            echo "⏹️ END: ${step} ($(ts))" >>"$LOG"
+            echo >>"$LOG"
+          }
 
           run_step prep_merge.py                   python scripts/prep_merge.py
           run_step chain_load_data.py              python scripts/chain_load_data.py


### PR DESCRIPTION
## Summary
- ensure the 03 Batter Adjustments run_step helper preserves the step name before shifting
- align the 05 Prep run_step helper with the same pattern so logs show human-friendly labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6cad162888332bce6906a4915792e